### PR TITLE
fix ordering in bulk pk-chunking

### DIFF
--- a/simple_salesforce/bulk.py
+++ b/simple_salesforce/bulk.py
@@ -183,6 +183,8 @@ class SFBulkType(object):
                                                session=self.session,
                                                headers=self.headers)
                 full_batch.extend(query_result.json())
+            if full_batch and 'Id' in full_batch[0]:
+                full_batch.sort(key=lambda x: x.get('Id'))
             return full_batch
 
         return result.json()


### PR DESCRIPTION
This MR add sort operation during data loading in bulk API query call with PK-Chunking header